### PR TITLE
Make file paths configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,34 @@
 # Recursive-PDF-EXTRACTION-AND-RAG
+
+## Configuration
+
+Paths used by the scripts are now configurable via environment variables or a
+`config.json` file in the repository root. Environment variables override values
+from the JSON file.
+
+Supported options:
+
+| Variable | Description |
+| -------- | ----------- |
+| `FIRESTORE_SERVICE_ACCOUNT` | Path to the Firestore service account JSON file |
+| `PDF_DIRECTORY` | Default directory containing PDFs for `main.py` |
+| `PROCESSED_COURSES_CACHE` | Location of the processed courses cache |
+| `COURSES_JSON_PATH` | Path to the courses JSON used by sample data loader |
+| `TRANSFER_SERVICE_ACCOUNT` | Service account for the transfer utility |
+| `RECEIVING_SERVICE_ACCOUNT` | Receiving database service account |
+| `SAMPLE_PDF_PATH` | Sample PDF path for tests |
+| `DOCUMENT_SOURCE` | Document source path for course outline generator |
+| `TEST_DIRECTORY` | Directory used by the RAG test script |
+
+Create a `config.json` with any of these keys to supply default values. For
+example:
+
+```json
+{
+  "PDF_DIRECTORY": "/data/pdfs",
+  "FIRESTORE_SERVICE_ACCOUNT": "/path/to/service.json"
+}
+```
+
+All scripts will fall back to these settings when command-line arguments are not
+provided.

--- a/Services/Firestore/firebase_service.py
+++ b/Services/Firestore/firebase_service.py
@@ -5,6 +5,7 @@ from typing import List, Optional
 from PdfQuestionGeneration.DataModels.course_model import CourseModel, CourseData
 from PdfQuestionGeneration.DataModels.question_model import Question
 from PdfQuestionGeneration.DataModels.document_model import Document
+from config import load_config
 
 class FireStore:
     _instance = None
@@ -16,8 +17,10 @@ class FireStore:
 
     def __init__(self):
         if not firebase_admin._apps:
+            config = load_config()
             try:
-                cred = credentials.Certificate("/home/awun/Documents/UNDEFINED MAIN/Scripts/PdfQuestionGeneration/Services/Firestore/service_token.json")
+                cred_path = config.firestore_service_account
+                cred = credentials.Certificate(cred_path)
                 firebase_admin.initialize_app(cred)
                 self.db = firestore.client()
                 print("Firebase initialized successfully.")

--- a/Services/RAG/Tests/rag_test.py
+++ b/Services/RAG/Tests/rag_test.py
@@ -1,2 +1,6 @@
-file_path = "/home/awun/Documents/UNDEFINED MAIN/StudyMaterials/textbooks/400/CHE/1/CHE 417/CHE 441 Lecture Note 2.pdf".split("/")
+from config import load_config
+
+config = load_config()
+
+file_path = config.sample_pdf_path.split("/")
 print(file_path)

--- a/Services/RAG/rag.py
+++ b/Services/RAG/rag.py
@@ -620,10 +620,12 @@ class RAG:
 
 
 if __name__ == '__main__':
+    from config import load_config
+    config = load_config()
     rag = RAG()
-    
+
     # Test the enhanced OCR system
-    test_directory = "/home/awun/Documents/UNDEFINED MAIN/StudyMaterials/textbooks/200"
+    test_directory = config.test_directory
     processed_files = rag.get_files_from_directory(test_directory)
 
     if processed_files:
@@ -636,5 +638,6 @@ if __name__ == '__main__':
     else:
         print("No files processed successfully.")
 
-    # ocr = rag.ocr_text_extraction("/home/awun/Documents/UNDEFINED MAIN/StudyMaterials/textbooks/400/CHE/1/CHE 417/plant design note.pdf")
+    # Example OCR call
+    # ocr = rag.ocr_text_extraction(config.sample_pdf_path)
     # print(ocr)

--- a/UtilityTools/Course Outline/rag_py.py
+++ b/UtilityTools/Course Outline/rag_py.py
@@ -352,9 +352,10 @@ def main():
     try:
         with CourseOutlineGenerator(api_key="AIzaSyB1qxAZA6G327lxiaI8pwkFKYRe1JDRz0o") as generator:
             # --- CONFIGURATION ---
+            from config import load_config
+            config = load_config()
             document_sources = [
-                # # A local file
-                '/home/awun/Documents/UNDEFINED MAIN/StudyMaterials/StudyMaterials/500/CVL/1/CVE 503_ STRUCTURAL ENGINEERING/CVE 503 PQ.pdf',
+                config.document_source,
             ]
             force_reprocessing = False
 

--- a/UtilityTools/Database Transfer/transfer_db.py
+++ b/UtilityTools/Database Transfer/transfer_db.py
@@ -48,8 +48,12 @@ class TransferDB:
 
 
 
-transfer_service_account_path = "/home/awun/Firebase/undefined/do_not_delete_undefined_325e.json"
-reciving_service_account_path = "/home/awun/Downloads/engineering-hub-7e5e1-firebase-adminsdk-fbsvc-deccf768c7.json"
+from config import load_config
+
+config = load_config()
+
+transfer_service_account_path = config.transfer_service_account_path
+reciving_service_account_path = config.reciving_service_account_path
 
 transferDB = TransferDB(transfer_db_service_account_path=transfer_service_account_path, recieving_db_service_account_path=reciving_service_account_path)
 data = transferDB.get_collection_data("course_data")

--- a/UtilityTools/Firestore/main/firestore.py
+++ b/UtilityTools/Firestore/main/firestore.py
@@ -7,9 +7,10 @@ import time
 
 from sampleData import DataFormatting
 from open_router import generate_multiple_topics
+from config import load_config
 
-# Path for the cache file
-PROCESSED_COURSES_CACHE = "/home/awun/Documents/UNDEFINED MAIN/Scripts/SampleData/firebase/Firestore/processed_courses.json"
+config = load_config()
+PROCESSED_COURSES_CACHE = config.processed_courses_cache
 
 class FirestoreManager:
     def __init__(self, service_account_path):
@@ -102,6 +103,5 @@ class FirestoreManager:
 
 
 if __name__ == "__main__":
-    manager = FirestoreManager(
-        service_account_path="/home/awun/Firebase/undefined/do_not_delete_undefined_325e.json")
+    manager = FirestoreManager(service_account_path=config.firestore_service_account)
     manager.create_course_data()

--- a/UtilityTools/Firestore/main/sampleData.py
+++ b/UtilityTools/Firestore/main/sampleData.py
@@ -36,7 +36,9 @@ class DataFormatting:
 
 
     def _read_json(self):
-        with open("/home/awun/Documents/UNDEFINED MAIN/Scripts/SampleData/firebase/Firestore/data/courses.json") as courses_file:
+        from config import load_config
+        config = load_config()
+        with open(config.courses_json_path) as courses_file:
             data = json.load(courses_file)
 
         return data

--- a/config.py
+++ b/config.py
@@ -1,0 +1,31 @@
+import os
+import json
+from dataclasses import dataclass
+
+CONFIG_FILE = os.getenv('CONFIG_FILE', 'config.json')
+
+@dataclass
+class Config:
+    firestore_service_account: str = os.getenv('FIRESTORE_SERVICE_ACCOUNT', '')
+    pdf_directory: str = os.getenv('PDF_DIRECTORY', '')
+    processed_courses_cache: str = os.getenv('PROCESSED_COURSES_CACHE', '')
+    courses_json_path: str = os.getenv('COURSES_JSON_PATH', '')
+    transfer_service_account_path: str = os.getenv('TRANSFER_SERVICE_ACCOUNT', '')
+    reciving_service_account_path: str = os.getenv('RECEIVING_SERVICE_ACCOUNT', '')
+    sample_pdf_path: str = os.getenv('SAMPLE_PDF_PATH', '')
+    document_source: str = os.getenv('DOCUMENT_SOURCE', '')
+    test_directory: str = os.getenv('TEST_DIRECTORY', '')
+
+
+def load_config() -> Config:
+    config = Config()
+    if os.path.exists(CONFIG_FILE):
+        try:
+            with open(CONFIG_FILE) as f:
+                data = json.load(f)
+            for field in config.__dataclass_fields__:
+                if getattr(config, field) == '' and field in data:
+                    setattr(config, field, data[field])
+        except Exception:
+            pass
+    return config

--- a/main.py
+++ b/main.py
@@ -7,12 +7,15 @@ from dotenv import load_dotenv
 import re
 import logging
 import json
+import argparse
+from config import load_config
 
 # --- Configuration ---
 logging.basicConfig(level=logging.INFO, format='%(asctime)s - %(levelname)s - %(message)s')
 
 load_dotenv()
 logging.info("Attempting to load environment variables from .env file.")
+config = load_config()
 
 GOOGLE_API_KEY = "AIzaSyB1qxAZA6G327lxiaI8pwkFKYRe1JDRz0o"
 if not GOOGLE_API_KEY:
@@ -227,9 +230,16 @@ def get_embeddings_by_collection(collection_name: str):
 if __name__ == "__main__":
     logging.info("========== Script Execution Started ==========")
     if GOOGLE_API_KEY and chroma_client:
-        pdf_directory = "/home/awun/Documents/UNDEFINED MAIN/StudyMaterials/CIVIL/CIVIL 300 LEVEL/300 LVL FIRST SEMESTER/CVE 301_ BASIC CIVIL ENGINEERING"
-        logging.info(f"Target PDF directory: {pdf_directory}")
-        walk_and_process(pdf_directory)
+        parser = argparse.ArgumentParser(description="Process PDFs for embeddings")
+        parser.add_argument("--pdf-directory", default=config.pdf_directory, help="Directory containing PDFs")
+        args = parser.parse_args()
+
+        pdf_directory = args.pdf_directory
+        if not pdf_directory:
+            logging.error("PDF directory not specified.")
+        else:
+            logging.info(f"Target PDF directory: {pdf_directory}")
+            walk_and_process(pdf_directory)
 
         # Example usage of the new function:
         # if os.path.exists(COLLECTIONS_JSON_PATH):


### PR DESCRIPTION
## Summary
- parameterize absolute paths using a shared config loader
- allow main.py to accept a `--pdf-directory` CLI argument
- update various scripts to read paths from configuration
- document new environment variables in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6886ed0de3dc8332aab20e3f81792797