### PR TITLE
Enable paragraph-based chunking with OCR

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,3 +36,7 @@ provided.
 ## Gemini Service
 
 The project includes a `GeminiService` class in `Services/Gemini` which wraps the Google Generative AI client. It defaults to `gemini-2.5-flash` for generation and `gemini-2.5-flash-lite` for OCR. A custom Pydantic `GeminiConfig` model provides type-checked generation settings.
+
+## Paragraph-based Chunking
+
+Text extraction utilities now support paragraph-level chunking. The `ocr_text_extraction` helper can combine OCR output across pages (pass `combine_pages=True`) and `chunk_text` accepts a `by_paragraph` flag to return one chunk per paragraph.

--- a/UtilityTools/Course Outline/rag_py.py
+++ b/UtilityTools/Course Outline/rag_py.py
@@ -180,7 +180,8 @@ class CourseOutlineGenerator:
 
     def intelligent_chunking(self, text: str, max_chunk_size_words: int = 300, overlap_words: int = 50) -> List[str]:
         if not text.strip(): return []
-        paragraphs = re.split(r'\n\s*\n', text.strip())
+        cleaned = re.sub(r"\n?-+ PAGE BREAK -+\n?", "\n\n", text.strip())
+        paragraphs = re.split(r'\n\s*\n', cleaned)
         chunks, current_chunk = [], ""
         for para in paragraphs:
             if not para.strip(): continue


### PR DESCRIPTION
## Summary
- add `combine_pages` option to OCR helper
- normalize page breaks and allow paragraph splitting in `chunk_text`
- use paragraph-based chunking when processing PDFs
- update CourseOutline `intelligent_chunking` to strip page markers
- document new behavior in README

## Testing
- `python -m py_compile main.py Services/RAG/helpers.py 'UtilityTools/Course Outline/rag_py.py'`

------
https://chatgpt.com/codex/tasks/task_e_6887c6f63a288332b86db8f124636822