### PR TITLE
Add OCR data model and integrate with OCR flow

### DIFF
--- a/DataModels/ocr_data_model.py
+++ b/DataModels/ocr_data_model.py
@@ -1,0 +1,13 @@
+from pydantic import BaseModel, Field
+
+
+class OCRData(BaseModel):
+    """Structured text extracted via Optical Character Recognition.
+
+    This model represents the raw textual output obtained from running OCR on a
+    document image. The :attr:`text` field contains the exact text returned by
+    the OCR process without any additional metadata or formatting.
+    """
+
+    text: str = Field(..., description="Text extracted from a page or document using OCR")
+

--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ provided.
 The project includes a `GeminiService` class in `Services/Gemini` which wraps the Google Generative AI client. It defaults to `gemini-2.5-flash` for generation and `gemini-2.5-flash-lite` for OCR. A custom Pydantic `GeminiConfig` model provides type-checked generation settings.
 
 The OCR helper now uses a prompt that encourages step-by-step reasoning for improved accuracy.
+OCR responses are validated against a simple `OCRData` Pydantic model which contains a
+single `text` field representing the extracted content.
 
 ## Paragraph-based Chunking
 

--- a/README.md
+++ b/README.md
@@ -37,9 +37,11 @@ provided.
 
 The project includes a `GeminiService` class in `Services/Gemini` which wraps the Google Generative AI client. It defaults to `gemini-2.5-flash` for generation and `gemini-2.5-flash-lite` for OCR. A custom Pydantic `GeminiConfig` model provides type-checked generation settings.
 
-The OCR helper now uses a prompt that encourages step-by-step reasoning for improved accuracy.
-OCR responses are validated against a simple `OCRData` Pydantic model which contains a
-single `text` field representing the extracted content.
+The OCR helper now uses a prompt that encourages step-by-step reasoning for improved
+accuracy. Responses are validated against a simple `OCRData` Pydantic model which
+contains a single `text` field representing the extracted content. The
+`GeminiService.ocr` method defaults to returning this model when no custom
+`response_model` is supplied.
 
 ## Paragraph-based Chunking
 

--- a/Services/RAG/helpers.py
+++ b/Services/RAG/helpers.py
@@ -6,6 +6,7 @@ from pathlib import Path
 import fitz
 
 from .. import GeminiService
+from DataModels.ocr_data_model import OCRData
 from ..UtilityTools.Caching.cache import Cache
 
 ACCEPTABLE_TEXT_PERCENTAGE = 0.85
@@ -103,13 +104,10 @@ def ocr_text_extraction(
         print(f"Page number: {page_num}")
         text = ""
         try:
-            response = gemini_service.ocr([img], prompt=OCR_PROMPT)
-            print("#" * 50)
-            print(response for i in response)
-            print("-" * 50)
-            print(response.get("text_content", ""))
-            print("#" * 50)
-            text = response.get("text_content", "") if isinstance(response, dict) else ""
+            response = gemini_service.ocr(
+                [img], prompt=OCR_PROMPT, response_model=OCRData
+            )
+            text = response.text
         except Exception as e:
             logging.error(f"OCR failed for page {page_num}: {e}")
         pages_data[page_num] = {


### PR DESCRIPTION
## Summary
- add `OCRData` pydantic model for structured OCR text
- integrate OCRData with `ocr_text_extraction`
- document OCRData usage in the README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python test.py` *(fails to retrieve embeddings, PostHog SSL errors)*

------
https://chatgpt.com/codex/tasks/task_e_688847c7cc74833291c6d542f420170f