### PR TITLE
Update OCR prompt with JSON response instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,10 +38,11 @@ provided.
 The project includes a `GeminiService` class in `Services/Gemini` which wraps the Google Generative AI client. It defaults to `gemini-2.5-flash` for generation and `gemini-2.5-flash-lite` for OCR. A custom Pydantic `GeminiConfig` model provides type-checked generation settings.
 
 The OCR helper now uses a prompt that encourages step-by-step reasoning for improved
-accuracy. Responses are validated against a simple `OCRData` Pydantic model which
-contains a single `text` field representing the extracted content. The
-`GeminiService.ocr` method defaults to returning this model when no custom
-`response_model` is supplied.
+accuracy and instructs Gemini to respond using JSON. Responses must be in the form
+`{"text": "<extracted text>"}`. They are validated against a simple `OCRData`
+Pydantic model which contains a single `text` field representing the extracted
+content. The `GeminiService.ocr` method defaults to returning this model when no
+custom `response_model` is supplied.
 
 ## Paragraph-based Chunking
 

--- a/Services/RAG/helpers.py
+++ b/Services/RAG/helpers.py
@@ -13,8 +13,9 @@ ACCEPTABLE_TEXT_PERCENTAGE = 0.85
 CACHE_FILE = "pdf_cache.json"
 OCR_PROMPT = (
     "Extract all text from this document image. "
-    "Pay special attention to latex and other engineering notation"
-    "Use step-by-step reasoning for higher accuracy and return only the text."
+    "Pay special attention to LaTeX and engineering notation. "
+    "Use step-by-step reasoning for accuracy. "
+    "Respond as JSON in the form {\"text\": \"<extracted text>\"}."
 )
 
 


### PR DESCRIPTION
## Summary
- update `OCR_PROMPT` so OCR results must be returned as `{ "text": "..." }`
- document the JSON response requirement for OCR in `README`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68884f261e64833290d514eb68bb6978