### PR TITLE
Improve Gemini configuration and defaults

### DIFF
--- a/DataModels/gemini_config.py
+++ b/DataModels/gemini_config.py
@@ -1,5 +1,5 @@
 from pydantic import BaseModel, Field
-from typing import Optional
+from typing import Optional, Type
 
 class GeminiConfig(BaseModel):
     """Configuration for Gemini generation requests."""
@@ -7,4 +7,7 @@ class GeminiConfig(BaseModel):
     max_output_tokens: int = Field(10000, description="Maximum tokens in the response")
     top_p: Optional[float] = Field(0.8, description="Nucleus sampling p value")
     top_k: Optional[int] = Field(None, description="Top-k sampling value")
-    response_schema: type = Field(..., description="This is the response schema that the user is to pass")
+    response_schema: Optional[Type[BaseModel]] = Field(
+        default=None,
+        description="Pydantic model describing the desired JSON response format",
+    )

--- a/Services/Gemini/gemini_service.py
+++ b/Services/Gemini/gemini_service.py
@@ -1,3 +1,7 @@
+"""Wrapper around the Google Generative AI client with typed configuration."""
+
+from __future__ import annotations
+
 import json
 from typing import Any, Dict, Iterable, List, Optional, Type, TypeVar
 
@@ -12,35 +16,20 @@ T = TypeVar("T", bound=BaseModel)
 DEFAULT_MODEL = "gemini-2.5-flash"
 OCR_MODEL = "gemini-2.5-flash-lite"
 
-class GeminiService:
-    """Simple wrapper around ``google.generativeai`` with typed configuration.
 
-    Parameters
-    ----------
-    model:
-        The default model used for text generation requests.
-    ocr_model:
-        The model specifically used when performing OCR operations.
-        OCR responses are parsed into :class:`~DataModels.ocr_data_model.OCRData`
-        objects unless a different Pydantic model is supplied.
-    generation_config:
-        Optional :class:`GeminiConfig` providing defaults for generation
-        settings. If omitted a new ``GeminiConfig`` instance with all default
-        values is used.
-    """
+class GeminiService:
+    """Simple wrapper around ``google.generativeai`` with typed configuration."""
 
     def __init__(self, model: str = DEFAULT_MODEL, ocr_model: str = OCR_MODEL,
                  generation_config: Optional[GeminiConfig] = None) -> None:
-        """Initialize the service with optional model overrides."""
-
         self.model = model
         self.ocr_model = ocr_model
-        # Use the provided generation configuration or fall back to defaults.
         self.default_config = generation_config or GeminiConfig()
 
-    def _to_generation_config(self, config: Optional[GeminiConfig | Dict[str, Any]]) -> genai.types.GenerationConfig:
-        """Convert various config representations into ``GenerationConfig``."""
-
+    def _to_generation_config(
+        self, config: Optional[GeminiConfig | Dict[str, Any]]
+    ) -> tuple[genai.types.GenerationConfig, Optional[list[dict[str, Any]]]]:
+        """Convert configuration data to a ``GenerationConfig`` and tools."""
         if config is None:
             config = self.default_config
         elif isinstance(config, dict):
@@ -48,32 +37,52 @@ class GeminiService:
         elif not isinstance(config, GeminiConfig):
             raise TypeError("generation_config must be GeminiConfig or dict")
 
-        return genai.types.GenerationConfig(
+        gen_config = genai.types.GenerationConfig(
             temperature=config.temperature,
             max_output_tokens=config.max_output_tokens,
             top_p=config.top_p,
             top_k=config.top_k,
-            response_mime_type="application/json",
+            response_mime_type="application/json" if config.response_schema else None,
         )
 
-    def _generate(self, parts: Iterable[Any], model: str,
-                  generation_config: Optional[GeminiConfig | Dict[str, Any]],
-                  response_model: Optional[Type[T]] = None) -> T | Dict[str, Any]:
-        """Internal helper to perform a generation request."""
+        tools = None
+        if config.response_schema:
+            tools = [
+                {
+                    "type": "function",
+                    "function": {
+                        "name": "response",
+                        "description": "Response schema",
+                        "parameters": config.response_schema.model_json_schema(),
+                    },
+                }
+            ]
+        return gen_config, tools
 
-        print(type(response_model))
-        gen_config = self._to_generation_config(generation_config)
-        gen_model = genai.GenerativeModel(model, generation_config=gen_config)
+    def _generate(
+        self,
+        parts: Iterable[Any],
+        model: str,
+        generation_config: Optional[GeminiConfig | Dict[str, Any]],
+        response_model: Optional[Type[T]] = None,
+    ) -> T | Dict[str, Any]:
+        """Internal helper to perform a generation request."""
+        gen_config, tools = self._to_generation_config(generation_config)
+        gen_model = genai.GenerativeModel(model, generation_config=gen_config, tools=tools)
         response = gen_model.generate_content(list(parts))
         data = json.loads(response.text)
-        print(data)
         if response_model:
             return response_model.model_validate(data)
         return data
 
-    def generate(self, prompt: str, *, model: Optional[str] = None,
-                 generation_config: Optional[GeminiConfig | Dict[str, Any]] = None,
-                 response_model: Optional[Type[T]] = None) -> T | Dict[str, Any]:
+    def generate(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        generation_config: Optional[GeminiConfig | Dict[str, Any]] = None,
+        response_model: Optional[Type[T]] = None,
+    ) -> T | Dict[str, Any]:
         """Generate text from a prompt using the specified model."""
         return self._generate([prompt], model or self.model, generation_config, response_model)
 
@@ -86,31 +95,24 @@ class GeminiService:
         generation_config: Optional[GeminiConfig | Dict[str, Any]] = None,
         response_model: Optional[Type[T]] = None,
     ) -> T | Dict[str, Any]:
-        """Perform OCR on provided images using Gemini flash-lite by default.
-
-        Unless a ``response_model`` is supplied, responses are validated against
-        :class:`~DataModels.ocr_data_model.OCRData` which simply contains a
-        ``text`` field with the extracted content.
-        """
-        print("Began OCR")
+        """Perform OCR on images using the lite model by default."""
         parts = [prompt] + images
-        print(f"Parts: {parts[0]}")
-        print(type(response_model))
-        generation_config = GeminiConfig(
-            temperature=0.9,
-            response_schema = OCRData,
-            top_p=0,
-            max_output_tokens=8000,
-        top_k=None, )
+        if generation_config is None:
+            generation_config = GeminiConfig(
+                temperature=0.9,
+                top_p=0,
+                top_k=None,
+                max_output_tokens=8000,
+                response_schema=OCRData,
+            )
+        else:
+            if isinstance(generation_config, dict):
+                generation_config = GeminiConfig(**generation_config)
+            if generation_config.response_schema is None:
+                generation_config.response_schema = OCRData
         return self._generate(
             parts,
             model or self.ocr_model,
             generation_config,
             response_model or OCRData,
         )
-
-
-
-if __name__ == "main":
-    gem = GeminiService()
-    i = gem.ocr()

--- a/Services/Gemini/tests/test_gemini_service.py
+++ b/Services/Gemini/tests/test_gemini_service.py
@@ -1,0 +1,27 @@
+import sys
+from pathlib import Path
+
+import google.generativeai as genai
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[3]))
+
+from Services.Gemini.gemini_service import GeminiService
+from DataModels.ocr_data_model import OCRData
+
+class DummyResponse:
+    def __init__(self, text):
+        self.text = text
+
+class DummyModel:
+    def __init__(self, *args, **kwargs):
+        self.kwargs = kwargs
+    def generate_content(self, parts):
+        return DummyResponse('{"text": "dummy"}')
+
+
+def test_ocr_returns_ocrdata(monkeypatch):
+    monkeypatch.setattr(genai, "GenerativeModel", DummyModel)
+    service = GeminiService()
+    result = service.ocr([{"mime_type": "image/png", "data": b""}])
+    assert isinstance(result, OCRData)
+    assert result.text == "dummy"


### PR DESCRIPTION
## Summary
- allow GeminiConfig to omit `response_schema`
- make GeminiService handle optional schema and support tools
- ensure OCR uses OCRData schema by default
- add basic test covering default OCR behaviour

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6888581afd048332beb35ddf64c1757d